### PR TITLE
Update deploy action version in build_universe.yaml

### DIFF
--- a/.github/workflows/build_universe.yaml
+++ b/.github/workflows/build_universe.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Deploy to main branch
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false
           branch: main


### PR DESCRIPTION
Hopefully this will remove the first two GitHub Actions warnings shown at https://github.com/r-releases/r-releases.r-universe.dev/actions/runs/8103472550.