### PR TITLE
Reorder steps in build_universe.yaml

### DIFF
--- a/.github/workflows/build_universe.yaml
+++ b/.github/workflows/build_universe.yaml
@@ -14,15 +14,6 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - name: Check out the r-releases.r-universe.dev.
-        uses: actions/checkout@v4
-    
-      - name: Check out r-releases.
-        uses: actions/checkout@v4
-        with:
-          repository: '${{ github.repository_owner }}/r-releases'
-          path: 'r-releases'
-
       - name: Install R.
         uses: r-lib/actions/setup-r@v2
         with:
@@ -37,10 +28,19 @@ jobs:
           )
         shell: Rscript {0}
 
+      - name: Check out the r-releases.r-universe.dev.
+        uses: actions/checkout@v4
+    
+      - name: Check out r-releases.
+        uses: actions/checkout@v4
+        with:
+          repository: '${{ github.repository_owner }}/r-releases'
+          path: 'r-releases'
+
       - name: Build packages.json
         run: |
           r.releases.utils::build_universe(
-            input = file.path("${{ github.repository_owner }}", "packages"),
+            input = file.path("r-releases", "packages"),
             output = "packages.json"
           )
         shell: Rscript {0}


### PR DESCRIPTION
This PR should make merge conflicts less likely in workflows that pull and push back to https://github.com/r-releases/r-releases.r-universe.dev.