### PR TITLE
Add version-tracking workflow

### DIFF
--- a/.github/workflows/record_versions.yaml
+++ b/.github/workflows/record_versions.yaml
@@ -36,7 +36,8 @@ jobs:
           r.releases.utils::record_versions(
             input = manifest = "versions.json",
             issues = "version_issues.json",
-            repos = "https://${{ github.repository_owner }}.r-universe.dev"
+            repos = "https://${{ github.repository_owner }}.r-universe.dev",
+            check_hash = FALSE
           )
         shell: Rscript {0}
 

--- a/.github/workflows/record_versions.yaml
+++ b/.github/workflows/record_versions.yaml
@@ -1,0 +1,51 @@
+name: build_universe
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  build_universe:
+    runs-on: macOS-latest
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - name: Install R.
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install helper R package.
+        run: |
+          install.packages(
+            pkgs = "r.releases.utils",
+            repos = "https://${{ github.repository_owner }}.r-universe.dev",
+            type = "binary"
+          )
+        shell: Rscript {0}
+
+      - name: Check out the r-releases.r-universe.dev.
+        uses: actions/checkout@v4
+    
+      - name: Record versions.
+        run: |
+          r.releases.utils::record_versions(
+            input = manifest = "versions.json",
+            issues = "version_issues.json",
+            repos = "https://${{ github.repository_owner }}.r-universe.dev"
+          )
+        shell: Rscript {0}
+
+      - name: Deploy to main branch
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: main
+          git-config-name: github-actions
+          git-config-email: actions@github.com
+          folder: .


### PR DESCRIPTION
Should make `verisons_issues.json` available for https://github.com/r-releases/help/issues/6 (@llrs). Before this will work, we need another release of `r.releases.utils` which incorporates https://github.com/r-releases/r.releases.utils/pull/9.